### PR TITLE
Fast Emoji support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = ["Viginum"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-demoji = "1.1.0"
 faiss-cpu = "1.9.0.post1"
 fasttext = "0.9.3"
 gensim = "4.3.3"


### PR DESCRIPTION
In the current implementation of D3lta, there is a major bottleneck on one very specific line of code: during dataset preprocessing, Emojis are removed by calling `demoji.replace`.

Demoji uses the list of all 4,590 official emoji sequences (including composite sequences made of multiple code points, such as "people holding hands: light skin tone, medium skin tone") in a large regex, which has a significant impact on performance.

This PR proposes a new implementation for the `remove_emojis` parameter, which uses a condensed regex to match emojis and similar symbols (such as ➔ or ☺︎ which are not in the Emoji table) based on their Unicode block. Composite emojis are also handled, by matching each sub-character along with the ZWJ that joins them together.

The benchmark below was run on a dataset of 20k documents (TikTok subtitles, ~1000 chars on average), and shows a **16x speedup** of the entire dataset preprocessing step.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/c55dcefc-fc13-4254-8ccb-fbb5c96f2777" />