### PR TITLE
fix(ci): specify python version in build workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,11 +21,7 @@ jobs:
         python-version: "3.x"
     
     - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
+      run: python3 -m pip install build --user
     
     - name: Build a binary wheel and a source tarball
       run: python3 -m build

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: "3.11"
     
     - name: Install pypa/build
       run: python3 -m pip install build --user


### PR DESCRIPTION
This PR updates the release GitHub Actions workflow to explicitly specify the Python version used for building.