### PR TITLE
fix(ci): run pypa/build via pipx

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,15 +20,8 @@ jobs:
       with:
         python-version: "3.x"
     
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    
     - name: Build a binary wheel and a source tarball
-      run: python3 -m build
+      run: pipx run build
 
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Removes warning caused by running pip as the `root` user.