### PR TITLE
feat(ci): add guards for critical CI steps for local debugging with nektos/act

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+env:
+  ACT: false  # env.ACT == true when running inside nektos/act
+
 jobs:
   build:
     name: Build distribution
@@ -52,6 +55,8 @@ jobs:
           path: dist/
 
       - run: gh release upload "${TAG_NAME}" dist/*.{tar.gz,whl}
+        # skip step when debugging locally via nektos/act
+        if: ${{ !env.ACT }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -74,6 +79,8 @@ jobs:
           path: dist/
 
       - name: Publish distribution to PyPI
+        # skip step when debugging locally via nektos/act
+        if: ${{ !env.ACT }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ pyrightconfig.json
 use_model_kaggle/
 include/
 .benchmarks
+.act-event.json


### PR DESCRIPTION
# Proposed changes

This PR adds workflow step guards to prevent execution of the following, critical steps when locally debugging the GitHub Actions release workflow via [nektos/act](https://github.com/nektos/act):
- Uploading public artifacts to a published release,
- Publishing the distribution to PyPI. 