### PR TITLE
fix(devcontainer): reflect changes to pyproject.toml after #22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir --upgrade pip
 RUN pipx install poetry==${POETRY_VERSION}
 
 WORKDIR /app
-COPY pyproject.toml poetry.lock setup.py README.md ./
+COPY pyproject.toml poetry.lock README.md LICENSE.txt ./
 # pre-install dependencies
 RUN --mount=type=cache,target=/root/.cache poetry install --no-root
 


### PR DESCRIPTION
- `setup.py` was removed in #22.
- The `LICENSE.txt` file is now referenced in the `pyproject.toml` after #22 and must therefore be present at when installating the project with poetry.