### PR TITLE
feat(devcontainer,tests): add devcontainer-related CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 		}
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	}
 }

--- a/.github/workflows/publish-devcontainer.yml
+++ b/.github/workflows/publish-devcontainer.yml
@@ -1,0 +1,29 @@
+name: Build and push the devcontainer
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-publish-devcontainer:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish Dev Container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/viginum-fr/d3lta
+          cacheFrom: ghcr.io/viginum-fr/d3lta

--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -1,0 +1,31 @@
+name: Test building the devcontainer
+
+on:  # test on any PRs and main branch changes
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-devcontainer:
+    name: Test building the dev container
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/viginum-fr/d3lta
+          cacheFrom: ghcr.io/viginum-fr/d3lta
+          push: never

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+MAKEFLAGS += --no-print-directory
+
+.PHONY: _login-to-github
+.PHONY: _trigger-act-job-with-github-token
+
+# prefixed with _ to prevent these commands from showing up in make's autocomplete
+_login-to-github:
+	gh auth login -s $(SCOPES)
+_trigger-act-job-with-github-token:
+	@act -j ${JOB} -s GITHUB_TOKEN="$$(gh auth token)"
+
+act-login-to-github-and-%:
+	@make _login-to-github SCOPES=${SCOPES}
+	@make act-$*
+
+act-login-to-github-and-build-devcontainer: SCOPES=read:packages
+act-login-to-github-and-build-and-publish-devcontainer: SCOPES=write:packages
+
+act-%:
+	@make _trigger-act-job-with-github-token JOB="$*"
+
+# ensures these commands are displayed in make's autocomplete
+act-build-devcontainer :
+act-build-and-publish-devcontainer :


### PR DESCRIPTION
- Add devcontainer building test.
- Add pre-built devcontainer publish to VIGINUM-FR ghcr.io registry for caching and faster re-builds.
- Re-add gh CLI devcontainer feature for retrieving tokens with the appropriate scopes.
- Add a Makefile with act-based commands for triggering the workflows introduced in the commit.